### PR TITLE
Add Spotify search cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Beatle is a small framework for building Discord bots using [discord.py](https:/
 
 - Minimal wrapper around `commands.Bot` with automatic cog loading
 - Example `ping` cog
+- Basic Spotify search command
 - Ready for extension with your own modules
 
 ## Quick start
@@ -27,6 +28,8 @@ bot.run("YOUR_TOKEN_HERE")
 ```
 
 3. Add additional cogs under `beatle/cogs` or specify your own package.
+
+Set `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` environment variables to enable Spotify commands.
 
 ## Testing
 

--- a/beatle/cogs/spotify.py
+++ b/beatle/cogs/spotify.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from discord.ext import commands
+import spotipy
+from spotipy.oauth2 import SpotifyClientCredentials
+
+
+class Spotify(commands.Cog):
+    """Commands for interacting with Spotify."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.sp = self._create_spotify_client()
+
+    def _create_spotify_client(self) -> Optional[spotipy.Spotify]:
+        """Create and return a Spotipy client if credentials are available."""
+        client_id = os.getenv("SPOTIFY_CLIENT_ID")
+        client_secret = os.getenv("SPOTIFY_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            return None
+        auth = SpotifyClientCredentials(client_id=client_id, client_secret=client_secret)
+        return spotipy.Spotify(auth_manager=auth)
+
+    @commands.command(name="spotify")
+    async def search(self, ctx: commands.Context, *, query: str) -> None:
+        """Search Spotify for a track and return the first result."""
+        if not self.sp:
+            await ctx.send("Spotify credentials not configured.")
+            return
+        results = self.sp.search(q=query, type="track", limit=1)
+        tracks = results.get("tracks", {}).get("items", [])
+        if not tracks:
+            await ctx.send("No tracks found.")
+            return
+        track = tracks[0]
+        name = track.get("name")
+        artists = ", ".join(a.get("name") for a in track.get("artists", []))
+        url = track.get("external_urls", {}).get("spotify", "")
+        await ctx.send(f"{name} by {artists}\n{url}")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Spotify(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 discord.py>=2.3.2
+
+spotipy>=2.25.0
+pytest-asyncio>=0.23.0

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,0 +1,38 @@
+import asyncio
+import discord
+from discord.ext import commands
+import pytest
+
+from beatle.cogs import spotify as spotify_cog
+
+
+class DummySpotify:
+    def search(self, q, type, limit):
+        return {
+            "tracks": {
+                "items": [
+                    {
+                        "name": "Song",
+                        "artists": [{"name": "Artist"}],
+                        "external_urls": {"spotify": "https://example.com"},
+                    }
+                ]
+            }
+        }
+
+
+@pytest.mark.asyncio
+async def test_spotify_cog_setup(monkeypatch):
+    monkeypatch.setattr(spotify_cog.Spotify, "_create_spotify_client", lambda self: DummySpotify())
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.default())
+    await spotify_cog.setup(bot)
+    assert "Spotify" in bot.cogs
+    cog = bot.cogs["Spotify"]
+    messages = []
+
+    async def _send(self, message):
+        messages.append(message)
+
+    ctx = type("Ctx", (), {"send": _send})()
+    await cog.search.callback(cog, ctx, query="test")
+    assert any("Song" in m for m in messages)


### PR DESCRIPTION
## Summary
- add a simple Spotify cog with a `spotify` search command
- document the new feature and env vars in README
- update requirements for Spotipy and pytest-asyncio
- test cog setup and command output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420d94564c83209d04bebdcc159c31