### PR TITLE
Add yt-dlp music playback cog

### DIFF
--- a/beatle/cogs/ytdl.py
+++ b/beatle/cogs/ytdl.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import yt_dlp
+import discord
+from discord.ext import commands
+
+
+class YTDLPlayer(commands.Cog):
+    """Play audio from URLs using yt-dlp."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.ytdl = yt_dlp.YoutubeDL({"format": "bestaudio/best", "quiet": True})
+
+    async def _ensure_voice(self, ctx: commands.Context) -> discord.VoiceClient | None:
+        if not getattr(ctx.author, "voice", None):
+            await ctx.send("You are not in a voice channel.")
+            return None
+        channel = ctx.author.voice.channel
+        if ctx.voice_client is None:
+            return await channel.connect()
+        if ctx.voice_client.channel != channel:
+            await ctx.voice_client.move_to(channel)
+        return ctx.voice_client
+
+    @commands.command(name="play")
+    async def play(self, ctx: commands.Context, *, url: str) -> None:
+        """Play audio from a given URL."""
+        voice = await self._ensure_voice(ctx)
+        if voice is None:
+            return
+        info = self.ytdl.extract_info(url, download=False)
+        source = discord.FFmpegPCMAudio(info["url"])
+        voice.play(source)
+        title = info.get("title", url)
+        await ctx.send(f"Now playing: {title}")
+
+    @commands.command(name="stop")
+    async def stop(self, ctx: commands.Context) -> None:
+        """Stop playback and leave the channel."""
+        if ctx.voice_client:
+            ctx.voice_client.stop()
+            await ctx.voice_client.disconnect()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(YTDLPlayer(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py>=2.3.2
 
 spotipy>=2.25.0
 pytest-asyncio>=0.23.0
+yt-dlp>=2025.5.22

--- a/tests/test_ytdl.py
+++ b/tests/test_ytdl.py
@@ -1,0 +1,61 @@
+import discord
+from discord.ext import commands
+import pytest
+
+from beatle.cogs import ytdl as ytdl_cog
+
+
+class DummyYTDL:
+    def extract_info(self, url, download=False):
+        return {"url": "http://audio", "title": "Test"}
+
+
+class DummyVoiceClient:
+    def __init__(self):
+        self.played = None
+        self.channel = None
+
+    async def move_to(self, channel):
+        self.channel = channel
+
+    def play(self, source):
+        self.played = source
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class DummyVoiceChannel:
+    async def connect(self):
+        return DummyVoiceClient()
+
+
+class DummyAuthor:
+    def __init__(self):
+        self.voice = type("Voice", (), {"channel": DummyVoiceChannel()})
+
+
+class DummyCtx:
+    def __init__(self):
+        self.author = DummyAuthor()
+        self.voice_client = None
+        self.sent = []
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_play(monkeypatch):
+    monkeypatch.setattr(ytdl_cog.yt_dlp, "YoutubeDL", lambda *a, **k: DummyYTDL())
+    monkeypatch.setattr(discord, "FFmpegPCMAudio", lambda url: url)
+
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.default())
+    await ytdl_cog.setup(bot)
+    cog = bot.cogs["YTDLPlayer"]
+    ctx = DummyCtx()
+    await cog.play.callback(cog, ctx, url="http://example.com")
+    assert any("Now playing" in m for m in ctx.sent)


### PR DESCRIPTION
## Summary
- enable music playback from URLs via a new `ytdl` cog
- include tests for the cog
- add `yt-dlp` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420efb1d988320bcd16a00e921ff76